### PR TITLE
Use ~ to install node-mapnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "async": "^2.4.0",
     "express": "^4.14.0",
     "geojson-bounds": "^1.0.1",
-    "mapnik": "^3.5.14",
+    "mapnik": "~3.5.14",
     "mkdirp": "^0.5.1",
     "pg": "^7.3.0",
     "progress": "^2.0.0",


### PR DESCRIPTION
This will protect your module from automatically upgrading to node-mapnik v3.7.0 (when it is published). This in turn will protect your users from breakages if they are running windows.

Refs mapnik/node-mapnik#848