### PR TITLE
Reorganize layer setup and lock down paleogeography layer somewhat

### DIFF
--- a/macrostrat_tileserver/cached_tiler.py
+++ b/macrostrat_tileserver/cached_tiler.py
@@ -70,6 +70,11 @@ class CachedVectorTilerFactory(VectorTilerFactory):
                 isinstance(layer, CachedStoredFunction) and cache != CacheMode.bypass
             )
 
+            try:
+                await layer.validate_request(pool, tile, tms, **kwargs)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
             if should_cache:
                 profile = await self.get_cache_profile_id(pool, layer)
                 content = await get_tile_from_cache(pool, profile, kwargs, tile, None)

--- a/macrostrat_tileserver/function_layer.py
+++ b/macrostrat_tileserver/function_layer.py
@@ -19,6 +19,17 @@ tile_settings = TileSettings()
 
 
 class StoredFunction(Function):
+    def __init__(self, function_name: str):
+        if "." in function_name:
+            id = function_name.split(".")[1]
+        id = id.replace("_", "-")
+
+        super().__init__(
+            sql="",
+            id=id,
+            function_name=function_name,
+        )
+
     type: str = "StoredFunction"
 
     def render_query(
@@ -50,6 +61,7 @@ class StoredFunction(Function):
         **kwargs: Any,
     ):
         """Get Tile Data."""
+
         # We only support TMS with valid EPSG code
         if not tms.crs.to_epsg():
             raise MissingEPSGCode(
@@ -67,3 +79,13 @@ class StoredFunction(Function):
             await transaction.rollback()
 
         return content
+
+    async def validate_request(
+        self,
+        pool: asyncpg.BuildPgPool,
+        tile: morecantile.Tile,
+        tms: morecantile.TileMatrixSet,
+        **kwargs: Any,
+    ):
+        """Validate request."""
+        pass

--- a/macrostrat_tileserver/paleogeography.py
+++ b/macrostrat_tileserver/paleogeography.py
@@ -1,0 +1,61 @@
+from .cached_tiler import CachedStoredFunction
+from typing import Any, Optional
+from buildpg import render
+
+
+class PaleoGeographyLayer(CachedStoredFunction):
+    _model_info: Optional[dict[str, Any]] = None
+
+    def __init__(self):
+        super().__init__(
+            "corelle_macrostrat.carto_slim_rotated",
+        )
+
+    async def validate_request(self, pool, tile, tms, **kwargs):
+        model = kwargs.get("model_id")
+        age = kwargs.get("t_step")
+        if model is None:
+            raise ValueError("model_id is required")
+        if age is None:
+            raise ValueError("age is required")
+        try:
+            model = int(model)
+            age = int(age)
+        except ValueError:
+            raise ValueError("model_id and age must be numbers")
+
+        if tile.z > 9:
+            raise ValueError(
+                "Zoom levels greater than 9 are not supported at this time."
+            )
+
+        model_data = await self.get_model_info(pool, model)
+        if model_data is None:
+            raise ValueError(f"model_id={model} not found")
+
+        if model_data["name"] == "PaleoPlates":
+            raise ValueError(
+                "PaleoPlates is not yet supported due to performance limitations."
+            )
+
+        min = model_data["min_age"] or 0
+        max = model_data["max_age"] or 4000
+        if age < min or age > max:
+            raise ValueError(
+                f"age={age} is outside the supported range for model_id={model}"
+            )
+
+        if age % 5 != 0:
+            raise ValueError(
+                "Only intervals of 5 million years are supported at this time."
+            )
+
+    async def get_model_info(self, pool, model_id) -> dict[str, Any]:
+        if self._model_info is not None:
+            return self._model_info
+        sql = "SELECT * FROM corelle.model WHERE id = :model_id"
+        q, p = render(sql, model_id=model_id)
+        async with pool.acquire() as conn:
+            model_info = await conn.fetchrow(q, *p)
+            self._model_info = dict(model_info)
+        return self._model_info


### PR DESCRIPTION
For our first public release of #27, we have ensured that the paleogeography functions are baseline performant for many cases. However, we want to be cautious rolling this out, so we have added a `validate_request` function that allows us to run the following checks:

- Both `t_step` and `model_id` query parameters are provided
- The request is between `min_age` and `max_age`
- Requests are at 5 million year intervals
- PaleoPlates is disabled

Eventually we will loosen some of those requirements, but for now it sands off some rough edges for the initial implementation.