### PR TITLE
Added 'oriented' field to line tile layers

### DIFF
--- a/macrostrat_tileserver/filterable/queries/lines.sql
+++ b/macrostrat_tileserver/filterable/queries/lines.sql
@@ -16,11 +16,12 @@ SELECT
   coalesce(l.name, '') AS name,
   coalesce(l.direction, '') AS direction,
   coalesce(l.type, '') AS "type",
-  tile_layers.tile_geom(z.geom, :envelope) AS geom
+  tile_layers.tile_geom(z.geom, :envelope) AS geom,
+  s.lines_oriented oriented
 FROM mvt_features z
 LEFT JOIN maps.lines l
   ON z.line_id = l.line_id
   AND l.scale::text = ANY(:linesize)
-LEFT JOIN maps.sources
-  ON z.source_id = sources.source_id
-WHERE sources.status_code = 'active'
+LEFT JOIN maps.sources s
+  ON z.source_id = s.source_id
+WHERE s.status_code = 'active'

--- a/macrostrat_tileserver/fixtures/04-carto-layer-defs.sql
+++ b/macrostrat_tileserver/fixtures/04-carto-layer-defs.sql
@@ -32,6 +32,7 @@ JOIN maps.lines l1
   ON l.line_id = l1.line_id;
 
 
+
 /**
   == MAP LEGEND INFO ==
   A utility view to assemble "carto-slim" tile data for a given map legend entry
@@ -171,6 +172,7 @@ expanded AS (
     coalesce(l.name, '') AS name,
     coalesce(l.direction, '') AS direction,
     coalesce(l.type, '') AS "type",
+    s.lines_oriented oriented,
     tile_layers.tile_geom(z.geom, mercator_bbox) AS geom
   FROM mvt_features z
   LEFT JOIN maps.lines l

--- a/macrostrat_tileserver/fixtures/05-map-layer-defs.sql
+++ b/macrostrat_tileserver/fixtures/05-map-layer-defs.sql
@@ -144,8 +144,10 @@ expanded AS (
     coalesce(q.name, '') AS name,
     coalesce(q.direction, '') AS direction,
     coalesce(q.type, '') AS "type",
+    sources.lines_oriented oriented,
     tile_layers.tile_geom(z.geom, mercator_bbox) AS geom
   FROM mvt_features z
+  JOIN maps.sources ON z.source_id = sources.source_id
   LEFT JOIN tile_layers.line_data q
     ON z.line_id = q.line_id
   WHERE q.scale = ANY(linesize)

--- a/macrostrat_tileserver/single_map/queries/lines.sql
+++ b/macrostrat_tileserver/single_map/queries/lines.sql
@@ -5,6 +5,7 @@ SELECT
   coalesce(l.name, '') AS name,
   coalesce(l.direction, '') AS direction,
   coalesce(l.type, '') AS "type",
+  s.lines_oriented oriented,
   tile_layers.tile_geom(l.geom, :envelope) AS geom
 FROM maps.lines l
 JOIN maps.sources s ON l.source_id = s.source_id


### PR DESCRIPTION
Following up on UW-Macrostrat/macrostrat#123, we are adding `oriented` fields to line layers for Macrostrat map tiles.